### PR TITLE
Updated jackson-dataformat-yaml --> jackson-dataformats-text

### DIFF
--- a/ratpack-config/ratpack-config.gradle
+++ b/ratpack-config/ratpack-config.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile project(":ratpack-func")
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {

--- a/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
+++ b/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
@@ -18,7 +18,7 @@ package ratpack.config.internal.source;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformats.text.YAMLFactory;
 import com.google.common.io.ByteSource;
 
 import java.net.URL;

--- a/ratpack-core/ratpack-core.gradle
+++ b/ratpack-core/ratpack-core.gradle
@@ -47,7 +47,7 @@ dependencies {
   compile 'org.javassist:javassist:3.22.0-GA'
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {


### PR DESCRIPTION
The jackson-dataformat-yaml package does not support underscores in large numbers. The package was added into jackson-dataformats-text and does include this support.

e.g. 1000 -> 1_000
     10000 -> 10_000
    100000 -> 100_000